### PR TITLE
changing to item_close to support recurring task completion

### DIFF
--- a/src/js/todoist.js
+++ b/src/js/todoist.js
@@ -189,10 +189,10 @@ function markTaskDone(id, token, success, error) {
       token: token,
       commands: JSON.stringify([
         {
-          type: 'item_complete',
+          type: 'item_close',
           uuid: uuid(),
           args: {
-            ids: '[' + id + ']'
+            id: id
           }
         }
       ])


### PR DESCRIPTION
I found that my recurring tasks were being archived. I reviewed the API [here](https://developer.todoist.com/?shell#close-item), and the close item method seems to fit better. It looks like the `markTaskDone` was maybe intended for marking multiple tasks as done, but I couldn't see that supported anywhere else.

P.S. This is my first pull request anywhere on anything. Be gracious :)