### PR TITLE
fix for 'Couldn't update workflow' notification

### DIFF
--- a/src/project/command.ts
+++ b/src/project/command.ts
@@ -164,7 +164,8 @@ export const Command: project.CommandFactory = compose({
         json: true
       })
         .then(response => {
-          if (response.body.version.match(/alfa|beta/).length > 0) return
+          let alfa_beta_match = response.body.version.match(/alfa|beta/)
+          if (alfa_beta_match && alfa_beta_match.length > 0) return
 
           if (response.body.version > FILES.workflowConfig.version) {
             Notification({


### PR DESCRIPTION
after initial installation and/or when the update check is expired (after 1 week) you get an annoying notification when using the Alfred workflow like when creating a task... see attached screenshot.
<img width="1393" alt="Screenshot 2020-06-01 at 12 49 27" src="https://user-images.githubusercontent.com/927293/83403067-3db22480-a408-11ea-8e60-22cc0ea112e4.png">
