### PR TITLE
style: satisfy linter variable casing

### DIFF
--- a/src/project/command.ts
+++ b/src/project/command.ts
@@ -164,8 +164,8 @@ export const Command: project.CommandFactory = compose({
         json: true
       })
         .then(response => {
-          let alfa_beta_match = response.body.version.match(/alfa|beta/)
-          if (alfa_beta_match && alfa_beta_match.length > 0) return
+          let alphaBetaMatch = response.body.version.match(/alfa|beta/)
+          if (alphaBetaMatch && alphaBetaMatch.length > 0) return
 
           if (response.body.version > FILES.workflowConfig.version) {
             Notification({


### PR DESCRIPTION
From what I can tell, [Travis CI is failing](https://travis-ci.org/github/moranje/alfred-workflow-todoist/jobs/773126454) for want of a particular variable casing:

```
167:17  error    Identifier 'alfa_beta_match' is not in camel case  @typescript-eslint/camelcase
168:15  error    Identifier 'alfa_beta_match' is not in camel case  @typescript-eslint/camelcase
168:34  error    Identifier 'alfa_beta_match' is not in camel case  @typescript-eslint/camelcase
```

Hopefully this change will permit Travis to complete its journey, and release the laudable `v5.8.4` version which includes [the bug-fixing commit](https://github.com/moranje/alfred-workflow-todoist/commit/88edbc57fe42b134b0cd08ba9a700ea059a8afc8) from @rosselm.