### PR TITLE
Changed it to the new API base path of Todoist.

### DIFF
--- a/src/project/__mocks__/references.ts
+++ b/src/project/__mocks__/references.ts
@@ -35,4 +35,4 @@ export const NOTIFIER_PATH = `${process.cwd()}/dist/workflow/notifier/terminal-n
 /**
  * The API base path.
  */
-export const TODOIST_API_URI = 'https://api.todoist.com/rest/v1'
+export const TODOIST_API_URI = 'https://api.todoist.com/rest/v2'

--- a/src/project/references.ts
+++ b/src/project/references.ts
@@ -42,4 +42,4 @@ export const NOTIFIER_PATH = `${WORKFLOW_PATH}/notifier/terminal-notifier.app/Co
 /**
  * The API base path.
  */
-export const TODOIST_API_URI = 'https://api.todoist.com/rest/v1'
+export const TODOIST_API_URI = 'https://api.todoist.com/rest/v2'


### PR DESCRIPTION
Just made a small change to API base path from https://api.todoist.com/rest/v1 to https://api.todoist.com/rest/v2